### PR TITLE
Implement staff role features with Auth0 RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ npm run build
 ```sh
 npm run lint
 ```
+
+## Environment Variables
+
+Create a `.env` file with the following keys:
+
+```sh
+VITE_API_BASE_URL=<backend url>
+VITE_AUTH0_DOMAIN=<auth0 domain>
+VITE_AUTH0_CLIENT_ID=<auth0 client id>
+VITE_AUTH0_AUDIENCE=<auth0 audience>
+VITE_AUTH0_REDIRECT_URI=<redirect uri>
+VITE_AUTH0_ROLES_CLAIM=<roles claim key>
+```

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,9 +3,18 @@ import { RouterLink, RouterView } from 'vue-router'
 import Yolo from './views/Yolo.vue'
 import NavMenu from './components/NavMenu.vue'
 import { useAuth0 } from '@auth0/auth0-vue'
-import { computed } from 'vue'
+import { computed, watchEffect } from 'vue'
+import { useRoles } from './composables/useRoles'
 
-const { logout, isAuthenticated, user } = useAuth0()
+const { logout, isAuthenticated } = useAuth0()
+const { roles } = useRoles()
+
+const isStaff = computed(() => roles.value.includes('staff'))
+
+watchEffect(() => {
+  console.log('[App] roles', roles.value)
+  console.log('[App] isStaff', isStaff.value)
+})
 
 const handleLogout = () => {
   logout({ logoutParams: { returnTo: window.location.origin + '/login' } })
@@ -18,10 +27,15 @@ const handleLogout = () => {
       <router-link to="/">ホーム</router-link> |
       <router-link to="/clothes-classification">制服分類</router-link> |
       <router-link to="/music-costume-classification">衣装分類</router-link> |
-      <router-link to="/new-image">新規画像登録</router-link> |
-      <a href="#" @click.prevent="logout">ログアウト</a>
+      <router-link to="/new-image">新規画像登録</router-link>
+      | <router-link to="/profile">プロフィール</router-link>
+      <span v-if="isStaff">
+        | <router-link to="/annotations">アノテーション一覧</router-link> |
+        <router-link to="/training">学習</router-link>
+      </span>
+      | <a href="#" @click.prevent="logout">ログアウト</a>
     </nav>
-    <router-view/>
+    <router-view />
   </div>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { RouterLink, RouterView } from 'vue-router'
-import Yolo from './views/Yolo.vue'
-import NavMenu from './components/NavMenu.vue'
+// Imports for views are handled by the router. Remove unused imports.
 import { useAuth0 } from '@auth0/auth0-vue'
 import { computed, watchEffect } from 'vue'
 import { useRoles } from './composables/useRoles'

--- a/src/api/annotations.ts
+++ b/src/api/annotations.ts
@@ -1,0 +1,27 @@
+import axios from 'axios'
+import { API_BASE_URL } from './endpoints'
+
+const api = axios.create({ baseURL: API_BASE_URL })
+
+export interface Annotation {
+  image: string
+  labelCategory: string
+  boxes: any[]
+}
+
+export const annotationsApi = {
+  async getAnnotations(token?: string): Promise<Annotation[]> {
+    const headers = token ? { Authorization: `Bearer ${token}` } : {}
+    console.log('[annotationsApi] GET /annotations')
+    const response = await api.get('/annotations', { headers })
+    console.log('[annotationsApi] fetched', response.data.length, 'annotations')
+    return response.data
+  },
+
+  async triggerTraining(token?: string): Promise<void> {
+    const headers = token ? { Authorization: `Bearer ${token}` } : {}
+    console.log('[annotationsApi] POST /train')
+    await api.post('/train', null, { headers })
+    console.log('[annotationsApi] training triggered')
+  }
+}

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -1,5 +1,7 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://192.168.207.227:18080/api';
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://192.168.207.227:18080/api'
 
 export const ENDPOINTS = {
-  ANNOTATIONS: `${API_BASE_URL}/annotate`
-}; 
+  ANNOTATIONS: `${API_BASE_URL}/annotate`,
+  ANNOTATION_LIST: `${API_BASE_URL}/annotations`,
+  TRAINING: `${API_BASE_URL}/train`
+}

--- a/src/composables/useRoles.ts
+++ b/src/composables/useRoles.ts
@@ -1,0 +1,36 @@
+import { ref, watchEffect } from 'vue'
+import { useAuth0 } from '@auth0/auth0-vue'
+
+const rolesClaim = import.meta.env.VITE_AUTH0_ROLES_CLAIM
+
+export function useRoles() {
+  const { isAuthenticated, user, getAccessTokenSilently } = useAuth0()
+  const roles = ref<string[]>([])
+
+  const loadRoles = async () => {
+    console.log('[useRoles] loading roles with claim', rolesClaim)
+    let list: any[] | undefined = (user.value as any)?.[rolesClaim]
+    if (!list && isAuthenticated.value) {
+      try {
+        const token = await getAccessTokenSilently()
+        const decoded = JSON.parse(atob(token.split('.')[1]))
+        list = decoded[rolesClaim] || []
+        console.log('[useRoles] roles from token', list)
+      } catch (e) {
+        console.error('[useRoles] Failed to read roles from token', e)
+      }
+    }
+    roles.value = Array.isArray(list) ? list : []
+    console.log('[useRoles] current roles', roles.value)
+  }
+
+  watchEffect(() => {
+    if (isAuthenticated.value) {
+      loadRoles()
+    } else {
+      roles.value = []
+    }
+  })
+
+  return { roles }
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -5,8 +5,9 @@ interface ImportMetaEnv {
   readonly VITE_AUTH0_CLIENT_ID: string
   readonly VITE_AUTH0_AUDIENCE: string
   readonly VITE_AUTH0_REDIRECT_URI: string
+  readonly VITE_AUTH0_ROLES_CLAIM: string
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv
-} 
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,11 +1,61 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import { authGuard } from '@auth0/auth0-vue'
+import { authGuard, useAuth0 } from '@auth0/auth0-vue'
+import { watch } from 'vue'
 import HomeView from '../views/HomeView.vue'
 import Yolo from '../views/Yolo.vue'
 import Annotation from '../views/Annotation.vue'
 import NewImageView from '../views/NewImageView.vue'
 import LoginView from '../views/LoginView.vue'
 import CategoriesView from '../views/CategoriesView.vue'
+import AnnotationList from '../views/AnnotationList.vue'
+import TrainingView from '../views/TrainingView.vue'
+import Unauthorized from '../views/Unauthorized.vue'
+import ProfileView from '../views/ProfileView.vue'
+
+const rolesClaim = import.meta.env.VITE_AUTH0_ROLES_CLAIM
+
+function roleGuard(requiredRoles: string[]) {
+  return (to: any, from: any, next: any) => {
+    const { isAuthenticated, isLoading, user, getAccessTokenSilently } = useAuth0()
+
+    const verify = async () => {
+      let roles: any[] = (user.value as any)?.[rolesClaim] || []
+      if (roles.length === 0 && isAuthenticated.value) {
+        try {
+          const token = await getAccessTokenSilently()
+          const decoded = JSON.parse(atob(token.split('.')[1]))
+          roles = decoded[rolesClaim] || []
+          console.log('[roleGuard] roles from token', roles)
+        } catch (e) {
+          console.error('Failed to load roles', e)
+        }
+      }
+
+      console.log('[roleGuard] verifying', {
+        route: to.path,
+        requiredRoles,
+        userRoles: roles,
+        isAuthenticated: isAuthenticated.value
+      })
+
+      if (isAuthenticated.value && requiredRoles.some((r) => roles.includes(r))) {
+        return next()
+      }
+      next('/unauthorized')
+    }
+
+    if (!isLoading.value) {
+      return verify()
+    }
+
+    watch(isLoading, () => {
+      if (!isLoading.value) {
+        console.log('[roleGuard] loading finished, verifying roles')
+        verify()
+      }
+    })
+  }
+}
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -44,9 +94,9 @@ const router = createRouter({
       path: '/annotation/:handleImage/:labelCategoryName',
       name: 'annotation',
       component: Annotation,
-      props: route => ({ 
-        handleImage: route.params.handleImage, 
-        labelCategoryName: route.params.labelCategoryName 
+      props: (route) => ({
+        handleImage: route.params.handleImage,
+        labelCategoryName: route.params.labelCategoryName
       }),
       beforeEnter: authGuard
     },
@@ -57,15 +107,38 @@ const router = createRouter({
       beforeEnter: authGuard
     },
     {
+      path: '/profile',
+      name: 'profile',
+      component: ProfileView,
+      beforeEnter: authGuard
+    },
+    {
       path: '/new-annotation/:handleImage/:labelCategoryName',
       name: 'new-annotation',
       component: Annotation,
-      props: route => ({ 
-        handleImage: route.params.handleImage, 
+      props: (route) => ({
+        handleImage: route.params.handleImage,
         labelCategoryName: route.params.labelCategoryName,
         isNewAnnotation: true
       }),
       beforeEnter: authGuard
+    },
+    {
+      path: '/annotations',
+      name: 'annotation-list',
+      component: AnnotationList,
+      beforeEnter: roleGuard(['staff'])
+    },
+    {
+      path: '/training',
+      name: 'training',
+      component: TrainingView,
+      beforeEnter: roleGuard(['staff'])
+    },
+    {
+      path: '/unauthorized',
+      name: 'unauthorized',
+      component: Unauthorized
     }
   ]
 })

--- a/src/views/AnnotationList.vue
+++ b/src/views/AnnotationList.vue
@@ -1,0 +1,32 @@
+<template>
+  <div>
+    <h1>アノテーション一覧</h1>
+    <div v-if="annotations.length === 0">データがありません</div>
+    <ul>
+      <li v-for="(ann, index) in annotations" :key="index">
+        <div>カテゴリ: {{ ann.labelCategory }}</div>
+        <div>画像: <img :src="ann.image" alt="img" style="max-width: 200px" /></div>
+        <pre>{{ ann.boxes }}</pre>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { annotationsApi, Annotation } from '../api/annotations'
+import { useAuth0 } from '@auth0/auth0-vue'
+
+const { getAccessTokenSilently } = useAuth0()
+const annotations = ref<Annotation[]>([])
+
+onMounted(async () => {
+  try {
+    const token = await getAccessTokenSilently()
+    annotations.value = await annotationsApi.getAnnotations(token)
+    console.log('[AnnotationList] loaded', annotations.value.length, 'items')
+  } catch (e) {
+    console.error(e)
+  }
+})
+</script>

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -1,0 +1,31 @@
+<template>
+  <div>
+    <h1>ユーザー情報</h1>
+    <div v-if="user">
+      <p><strong>名前:</strong> {{ user.name }}</p>
+      <p><strong>メール:</strong> {{ user.email }}</p>
+      <p><strong>ロール:</strong></p>
+      <ul>
+        <li v-for="role in roles" :key="role">{{ role }}</li>
+      </ul>
+      <p><strong>残りアノテーション回数:</strong> {{ annotationRemaining }}</p>
+      <p><strong>残り検出回数:</strong> {{ detectionRemaining }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useAuth0 } from '@auth0/auth0-vue'
+import { useRoles } from '../composables/useRoles'
+
+const { user } = useAuth0()
+const { roles } = useRoles()
+
+console.log('[ProfileView] user', user.value)
+console.log('[ProfileView] roles', roles.value)
+
+// TODO: Replace with values from backend when available
+const annotationRemaining = ref('--')
+const detectionRemaining = ref('--')
+</script>

--- a/src/views/TrainingView.vue
+++ b/src/views/TrainingView.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <h1>学習ページ</h1>
+    <button @click="startTraining" :disabled="loading">
+      {{ loading ? '学習中...' : '学習開始' }}
+    </button>
+    <p v-if="message">{{ message }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { annotationsApi } from '../api/annotations'
+import { useAuth0 } from '@auth0/auth0-vue'
+
+const { getAccessTokenSilently } = useAuth0()
+const loading = ref(false)
+const message = ref('')
+
+const startTraining = async () => {
+  try {
+    loading.value = true
+    const token = await getAccessTokenSilently()
+    console.log('[TrainingView] starting training')
+    await annotationsApi.triggerTraining(token)
+    console.log('[TrainingView] training started')
+    message.value = '学習を開始しました'
+  } catch (e) {
+    console.error('[TrainingView] failed to start training', e)
+    message.value = '学習開始に失敗しました'
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/src/views/Unauthorized.vue
+++ b/src/views/Unauthorized.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>権限がありません</h1>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- expand environment variables to include Auth0 roles claim
- add API helpers for annotations and training trigger
- extend API endpoints
- add role-based router guard and new routes
- create staff-only pages for viewing annotations and triggering training
- show new staff links in navigation
- add a profile page to view the current user info and roles
- document environment variable for Auth0 roles claim
- decode roles from access token so staff pages work correctly
- output helpful console logs for debugging roles and API interactions

## Testing
- `npx prettier -w src/App.vue src/api/annotations.ts src/composables/useRoles.ts src/router/index.ts src/views/AnnotationList.vue src/views/ProfileView.vue src/views/TrainingView.vue`
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_684d48dc6d4083268bdb6275283a2084